### PR TITLE
changed demo url to primary repo's github pages

### DIFF
--- a/README.mkdn
+++ b/README.mkdn
@@ -12,7 +12,7 @@ Start ->
 -> Finish.
 
 ## Demo
-[here](http://lkorth.github.com/kudos/)
+[here](http://masukomi.github.com/kudos/)
 
 # Basic Usage:
 


### PR DESCRIPTION
The demo url in the README was pointing to lkorth's demo repo. It now points to the canonical one.

--cc @ChasManRors
